### PR TITLE
本番環境で通知のマークが表示されない問題について

### DIFF
--- a/db/migrate/20240531133552_update_null_read_values_in_notifications.rb
+++ b/db/migrate/20240531133552_update_null_read_values_in_notifications.rb
@@ -1,0 +1,5 @@
+class UpdateNullReadValuesInNotifications < ActiveRecord::Migration[7.1]
+  def up
+    execute "UPDATE notifications SET read = false WHERE read IS NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_31_132619) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_31_133552) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
# 概要

本番環境で通知のマークが表示されない問題について

## 実装内容

- [x]  readカラムにnull規制をかけたが以前にnullのデータがあるためデプロイできずマイグレーションファイルを作成し現在のnullをfalseに変えるように記述しました